### PR TITLE
URI Specification on Google CDN link

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@ Numbers outside the range 0-1 may also be used.</td>
 
 </div>
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.js"></script>
 <script src="js/jquery.event.frame.js"></script>
 <script src="js/jquery.jparallax.js"></script>
 <script type="text/javascript">


### PR DESCRIPTION
Fixes `file://` page viewing.
