### PR TITLE
Added URIs to Google CDN links in demo files

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -64,7 +64,7 @@
 
 </div>
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.js"></script>
 <script src="../js/jquery.jparallax.min.js"></script>
 <script type="text/javascript">
 

--- a/demos/remotecontrol.html
+++ b/demos/remotecontrol.html
@@ -100,7 +100,7 @@
 
 </div>
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.js"></script>
 <script src="../js/jquery.jparallax.min.js"></script>
 <script type="text/javascript">
 

--- a/demos/stalkbuttons.html
+++ b/demos/stalkbuttons.html
@@ -419,7 +419,7 @@
 
 </div>
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.js"></script>
 <script src="../js/jquery.jparallax.min.js"></script>
 <script type="text/javascript">
 

--- a/demos/target.html
+++ b/demos/target.html
@@ -43,7 +43,7 @@
       <img class="parallax-layer" src="http://webdev.stephband.info/jparallax/images/parallax_target/target_red.png" alt="" />
   </div>
 
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.js"></script>
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.js"></script>
   <script src="../js/jquery.jparallax.min.js"></script>
   <script type="text/javascript">
   

--- a/demos/thumbnails.html
+++ b/demos/thumbnails.html
@@ -95,7 +95,7 @@
 
 </div>
 
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.js"></script>
 <script src="../js/jquery.jparallax.min.js"></script>
 <script type="text/javascript">
 


### PR DESCRIPTION
Same change as SHA: alampros@b2e96ac891b3b5e0d2185808a48876c62871cba6

Sorry for the double pull request – I missed the demo files!
