### PR TITLE
Throw error for event frame inclusion

### DIFF
--- a/js/jquery.jparallax.js
+++ b/js/jquery.jparallax.js
@@ -354,6 +354,9 @@ function update(e){
 }
 
 jQuery.fn[plugin] = function(o){
+    if (undefined === jQuery.event.special.frame) {
+        throw "jquery.event.frame is required for jparallax to work"
+    }
     var global = jQuery.extend({}, jQuery.fn[plugin].options, o),
         args = arguments,
         layers = this;


### PR DESCRIPTION
Added a check for `jQuery.event.special.frame` to ensure that event.frame has been included when `parallax()` is called. If it has not, throw an error rather than failing silently.

fixes #23
