### PR TITLE
Adding jQuery source reference to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 	<title>jQuery.parallax</title>
 	
 	<script>document.documentElement.className = 'js';</script>
+	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.js"></script>
 	
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0" />
 	<!-- Force latest IE rendering engine & Chrome Frame -->


### PR DESCRIPTION
The index was missing the reference and the first parallax example wasn't working. I just added this line based on the demos/\* files which were including the line and were working.
