### PR TITLE
Feature #90: Adding touch compatibility (new event listeners).

### DIFF
--- a/js/jquery.parallax.js
+++ b/js/jquery.parallax.js
@@ -513,7 +513,23 @@
 	
 	// Pick up and store mouse position on document: IE does not register
 	// mousemove on window.
-	doc.on('mousemove.parallax', function(e){
-		mouse = [e.pageX, e.pageY];
+	doc.on('mousemove.parallax touchstart.parallax touchmove.parallax touchend.parallax', function(e){
+		var x, y;
+		if (e.pageX) {
+			x = e.pageX;
+			y = e.pageY;
+
+		} else if (e.originalEvent.touches) {
+			var touches = e.originalEvent.touches;
+			if (touches.length == 0) return;
+
+			x = touches[0].pageX;
+			y = touches[0].pageY;
+
+		} else {
+			// No coords, nothing to do.
+			return;
+		}
+		mouse = [x, y];
 	});
 }(jQuery));


### PR DESCRIPTION
Currently a work in progress; still needs a proper initialization on load. Possibly as a configuration parameter, since naturally you cannot hover over anything with a touch device, but you can swipe. Only works currently if you tap first on the viewport and then swipe around. The touch emulates a `mouseenter` event. The idea then would probably be to trigger a `mousemove` event on any of the touch events in case it hasn't already been triggered.